### PR TITLE
Release version 3.0.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.8] - 2025-08-10
+
 - GUI: Speedup startup by concurrently bootstrapping Tor and requesting the user to select a wallet
 - GUI: Add white background to QR code modal to make it better scannable
 - GUI + CLI + ASB: Add `/dns4/rendezvous.observer/tcp/8888/p2p/12D3KooWMjceGXrYuGuDMGrfmJxALnSDbK4km6s1i1sJEgDTgGQa` to the default list of rendezvous points
@@ -624,7 +626,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/eigenwallet/core/compare/3.0.0-beta.7...HEAD
+[unreleased]: https://github.com/eigenwallet/core/compare/3.0.0-beta.8...HEAD
+[3.0.0-beta.8]: https://github.com/eigenwallet/core/compare/3.0.0-beta.7...3.0.0-beta.8
 [3.0.0-beta.7]: https://github.com/eigenwallet/core/compare/3.0.0-beta.7...3.0.0-beta.7
 [3.0.0-beta.7]: https://github.com/eigenwallet/core/compare/3.0.0-beta.6...3.0.0-beta.7
 [3.0.0-beta.6]: https://github.com/eigenwallet/core/compare/3.0.0-beta.5...3.0.0-beta.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10510,7 +10510,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -13273,7 +13273,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 dependencies = [
  "anyhow",
  "dfx-swiss-sdk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unstoppableswap-gui-rs"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 authors = [ "binarybaron", "einliterflasche", "unstoppableswap" ]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "eigenwallet",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "identifier": "net.unstoppableswap.gui",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 authors = ["The COMIT guys <hello@comit.network>"]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @binarybaron!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/eigenwallet/core/actions/runs/16864175240.
I've updated the changelog and bumped the versions in the manifest files in this commit: 3d58cf5b8d42ab4c29df4de814006ae9079e8773.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers to 3.0.0-beta.8 across relevant files and configuration.
  * Added a new changelog entry for version 3.0.0-beta.8, including updated version comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->