### PR TITLE
Display last four transactions and view all

### DIFF
--- a/src-gui/src/renderer/layout/mobile/App.mobile.tsx
+++ b/src-gui/src/renderer/layout/mobile/App.mobile.tsx
@@ -10,6 +10,7 @@ import HomePage from "./pages/HomePage";
 import GlobalSnackbarProvider from "renderer/components/snackbar/GlobalSnackbarProvider";
 import SettingsPage from "./pages/SettingsPage";
 import FeedbackPage from "./pages/FeedbackPage";
+import TransactionsPage from "./pages/HistoryPage";
 
 export default function App() {
   return (
@@ -36,7 +37,7 @@ function InnerContent() {
         <Route path="/" element={<HomePage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/feedback" element={<FeedbackPage />} />
-        {/* <Route path="/history" element={<HistoryPage />} /> */}
+        <Route path="/transactions" element={<TransactionsPage />} />
       </Routes>
     </Box>
   );

--- a/src-gui/src/renderer/layout/mobile/pages/HistoryPage.tsx
+++ b/src-gui/src/renderer/layout/mobile/pages/HistoryPage.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import {
+  Box,
+  IconButton,
+  Typography,
+  Stack,
+  Divider,
+} from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import { ChevronLeft } from "@mui/icons-material";
+import { useAppSelector } from "store/hooks";
+import TransactionItem from "renderer/components/pages/monero/components/TransactionItem";
+import { TransactionInfo } from "models/tauriModel";
+import dayjs from "dayjs";
+import _ from "lodash";
+
+export default function TransactionsPage() {
+  const navigate = useNavigate();
+  const { history } = useAppSelector((state) => state.wallet.state);
+  
+  const hasTransactions = history && history.transactions && history.transactions.length > 0;
+
+  return (
+    <Box>
+      {/* Header with back button */}
+      <Box 
+        sx={{ 
+          px: 2, 
+          pt: 3, 
+          display: "flex", 
+          alignItems: "center", 
+          gap: 1, 
+          position: "sticky", 
+          top: 0, 
+          backgroundColor: "background.paper", 
+          zIndex: 1 
+        }}
+      >
+        <IconButton onClick={() => navigate("/", { viewTransition: true })}>
+          <ChevronLeft />
+        </IconButton>
+        <Typography variant="h5">Transactions</Typography>
+      </Box>
+      
+      {/* Content */}
+      <Box sx={{ p: 2 }}>
+        {!hasTransactions ? (
+          <Typography variant="body2" color="text.secondary" sx={{ textAlign: "center", mt: 4 }}>
+            No transactions found
+          </Typography>
+        ) : (
+          <AllTransactionHistory transactions={history!.transactions} />
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+// Component to display all transactions grouped by date
+function AllTransactionHistory({
+  transactions,
+}: {
+  transactions: TransactionInfo[];
+}) {
+  // Group transactions by date
+  const transactionGroups = _(transactions)
+    .groupBy((tx) => dayjs(tx.timestamp * 1000).format("YYYY-MM-DD"))
+    .map((txs, dateKey) => ({
+      date: dateKey,
+      displayDate: dayjs(dateKey).format("MMMM D, YYYY"),
+      transactions: _.orderBy(txs, ["timestamp"], ["desc"]),
+    }))
+    .orderBy(["date"], ["desc"])
+    .value();
+
+  return (
+    <Stack spacing={3}>
+      {transactionGroups.map((group) => (
+        <Box key={group.date}>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ mb: 2, fontSize: "0.75rem", fontWeight: 600 }}
+          >
+            {group.displayDate}
+          </Typography>
+          <Stack spacing={1.5}>
+            {group.transactions.map((tx, index) => (
+              <React.Fragment key={tx.tx_hash}>
+                <TransactionItem transaction={tx} />
+                {index < group.transactions.length - 1 && <Divider sx={{ opacity: 0.3 }} />}
+              </React.Fragment>
+            ))}
+          </Stack>
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/src-gui/src/renderer/layout/mobile/pages/HomePage.tsx
+++ b/src-gui/src/renderer/layout/mobile/pages/HomePage.tsx
@@ -150,7 +150,10 @@ export default function HomePage() {
             </Typography>
           </Stack>
         ) : (
-          <MobileTransactionHistory transactions={history!.transactions} />
+          <MobileTransactionHistory 
+            transactions={history!.transactions} 
+            onViewAll={() => navigate("/transactions", { viewTransition: true })}
+          />
         )}
       </Box>
 
@@ -213,50 +216,41 @@ function GetStartedCard({
 // Mobile-specific transaction history component
 function MobileTransactionHistory({
   transactions,
+  onViewAll,
 }: {
   transactions: TransactionInfo[];
+  onViewAll?: () => void;
 }) {
-  // Group transactions by date
-  const transactionGroups = _(transactions)
-    .groupBy((tx) => dayjs(tx.timestamp * 1000).format("YYYY-MM-DD"))
-    .map((txs, dateKey) => ({
-      date: dateKey,
-      displayDate: dayjs(dateKey).format("MMMM D, YYYY"),
-      transactions: _.orderBy(txs, ["timestamp"], ["desc"]),
-    }))
-    .orderBy(["date"], ["desc"])
-    .take(3) // Show only the most recent 3 groups for mobile
-    .value();
+  // Get the 4 most recent transactions
+  const recentTransactions = _.orderBy(transactions, ["timestamp"], ["desc"]).slice(0, 4);
 
   return (
-    <Stack spacing={3}>
-      {transactionGroups.map((group) => (
-        <Box key={group.date}>
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ mb: 1, fontSize: "0.75rem" }}
+    <Stack spacing={2}>
+      <Stack spacing={1.5}>
+        {recentTransactions.map((tx, index) => (
+          <React.Fragment key={tx.tx_hash}>
+            <TransactionItem transaction={tx} />
+            {index < recentTransactions.length - 1 && <Divider sx={{ opacity: 0.3 }} />}
+          </React.Fragment>
+        ))}
+      </Stack>
+      
+      {transactions.length > 4 && onViewAll && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+          <Button
+            variant="outlined"
+            onClick={onViewAll}
+            sx={{
+              borderRadius: 20,
+              px: 3,
+              py: 1,
+              textTransform: "none",
+              fontWeight: 500,
+            }}
           >
-            {group.displayDate}
-          </Typography>
-          <Stack spacing={1.5}>
-            {group.transactions.slice(0, 3).map((tx) => (
-              <React.Fragment key={tx.tx_hash}>
-                <TransactionItem transaction={tx} />
-                <Divider sx={{ opacity: 0.3 }} />
-              </React.Fragment>
-            ))}
-          </Stack>
+            View all
+          </Button>
         </Box>
-      ))}
-      {transactions.length > 9 && (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ textAlign: "center", fontStyle: "italic" }}
-        >
-          Showing recent transactions only
-        </Typography>
       )}
     </Stack>
   );


### PR DESCRIPTION
Limit mobile home page transactions to the last 4 and add a "View all" button leading to a new page displaying all transactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-25805908-1ee0-4d15-ae74-d4b487498c80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25805908-1ee0-4d15-ae74-d4b487498c80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

