### PR TITLE
Release version 3.0.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.11] - 2025-08-20
+
 - ORCHESTRATOR: We incorrectly passed the `--mainnet` flag to the `asb` binary but it is the default for the asb.
 - CONTROLLER: Add a `bitcoin-seed` command to the controller. You can use it to export the descriptor of the internal Bitcoin wallet.
 - CLI + GUI + ASB: Accept self-signed TLS certificates and TLS certificates with older protocol versions.
@@ -643,7 +645,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/eigenwallet/core/compare/3.0.0-beta.10...HEAD
+[unreleased]: https://github.com/eigenwallet/core/compare/3.0.0-beta.11...HEAD
+[3.0.0-beta.11]: https://github.com/eigenwallet/core/compare/3.0.0-beta.10...3.0.0-beta.11
 [3.0.0-beta.10]: https://github.com/eigenwallet/core/compare/3.0.0-beta.9...3.0.0-beta.10
 [3.0.0-beta.9]: https://github.com/eigenwallet/core/compare/3.0.0-beta.8...3.0.0-beta.9
 [3.0.0-beta.8]: https://github.com/eigenwallet/core/compare/3.0.0-beta.7...3.0.0-beta.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10607,7 +10607,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -13370,7 +13370,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 dependencies = [
  "anyhow",
  "dfx-swiss-sdk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unstoppableswap-gui-rs"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 authors = [ "binarybaron", "einliterflasche", "unstoppableswap" ]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "eigenwallet",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0-beta.11",
   "identifier": "net.unstoppableswap.gui",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 authors = ["The COMIT guys <hello@comit.network>"]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @Einliterflasche!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/eigenwallet/core/actions/runs/17093430926.
I've updated the changelog and bumped the versions in the manifest files in this commit: d8567d9077b4b991a53d6e8dc6bbc462a581c9fe.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a command to export the internal Bitcoin wallet descriptor.
  * CLI and GUI now accept self-signed TLS certificates and older TLS protocol versions for improved connectivity.

* Documentation
  * Updated changelog with a new 3.0.0-beta.11 entry and revised navigation/compare links.

* Chores
  * Bumped application and component versions to 3.0.0-beta.11 across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->