### PR TITLE
 fix: Re-set restore height to chain tip after loading transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,7 @@ checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2497,6 +2498,24 @@ dependencies = [
  "group",
  "rand_core 0.6.4",
  "rustversion",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "dalek-ff-group"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3665951647a80a4ce58562c8bfc5df9d2a2d4f0021b72a0c0ddf408737feeb"
+dependencies = [
+ "crypto-bigint",
+ "curve25519-dalek 4.1.3",
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "rand_core 0.6.4",
+ "rustversion",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2932,6 +2951,19 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest 0.10.7",
+ "hex",
+ "md-5",
+ "rand 0.8.5",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6451,6 +6483,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "monero-address"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "monero-base58",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-base58"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "monero-primitives 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+]
+
+[[package]]
+name = "monero-borromean"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "monero-generators 0.4.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-primitives 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "std-shims 0.1.4",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-bulletproofs"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "monero-generators 0.4.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-primitives 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "rand_core 0.6.4",
+ "std-shims 0.1.4",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-clsag"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "group",
+ "monero-generators 0.4.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-primitives 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "std-shims 0.1.4",
+ "subtle",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
 name = "monero-epee-bin-serde"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6463,14 +6561,29 @@ dependencies = [
 [[package]]
 name = "monero-generators"
 version = "0.4.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "crypto-bigint",
+ "curve25519-dalek 4.1.3",
+ "dalek-ff-group 0.4.4",
+ "group",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "sha3",
+ "std-shims 0.1.4",
+ "subtle",
+]
+
+[[package]]
+name = "monero-generators"
+version = "0.4.0"
 source = "git+https://github.com/serai-dex/serai#eab5d9e64fd27076a49583e5f45901d34b463c01"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "dalek-ff-group",
+ "dalek-ff-group 0.4.1",
  "group",
- "monero-io",
+ "monero-io 0.1.0 (git+https://github.com/serai-dex/serai)",
  "sha3",
- "std-shims",
+ "std-shims 0.1.1",
  "subtle",
 ]
 
@@ -6481,7 +6594,7 @@ dependencies = [
  "anyhow",
  "futures",
  "monero",
- "monero-rpc",
+ "monero-rpc 0.1.0",
  "monero-sys",
  "rand 0.8.5",
  "reqwest 0.12.22",
@@ -6494,10 +6607,64 @@ dependencies = [
 [[package]]
 name = "monero-io"
 version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "std-shims 0.1.4",
+]
+
+[[package]]
+name = "monero-io"
+version = "0.1.0"
 source = "git+https://github.com/serai-dex/serai#eab5d9e64fd27076a49583e5f45901d34b463c01"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "std-shims",
+ "std-shims 0.1.1",
+]
+
+[[package]]
+name = "monero-mlsag"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "monero-generators 0.4.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-primitives 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "std-shims 0.1.4",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-oxide"
+version = "0.1.4-alpha"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "hex-literal 0.4.1",
+ "monero-borromean",
+ "monero-bulletproofs",
+ "monero-clsag",
+ "monero-generators 0.4.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-mlsag",
+ "monero-primitives 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "std-shims 0.1.4",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-primitives"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "monero-generators 0.4.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "monero-io 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "sha3",
+ "std-shims 0.1.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -6506,10 +6673,10 @@ version = "0.1.0"
 source = "git+https://github.com/serai-dex/serai#eab5d9e64fd27076a49583e5f45901d34b463c01"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "monero-generators",
- "monero-io",
+ "monero-generators 0.4.0 (git+https://github.com/serai-dex/serai)",
+ "monero-io 0.1.0 (git+https://github.com/serai-dex/serai)",
  "sha3",
- "std-shims",
+ "std-shims 0.1.1",
  "zeroize",
 ]
 
@@ -6534,6 +6701,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "monero-rpc"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "hex",
+ "monero-address",
+ "monero-oxide",
+ "serde",
+ "serde_json",
+ "std-shims 0.1.4",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
 name = "monero-rpc-pool"
 version = "0.1.0"
 dependencies = [
@@ -6549,7 +6732,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "monero",
- "monero-rpc",
+ "monero-rpc 0.1.0",
  "rand 0.8.5",
  "regex",
  "reqwest 0.11.27",
@@ -6578,10 +6761,23 @@ version = "0.1.0"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "hex",
- "monero-primitives",
+ "monero-primitives 0.1.0 (git+https://github.com/serai-dex/serai)",
  "rand_core 0.6.4",
- "std-shims",
+ "std-shims 0.1.1",
  "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-simple-request-rpc"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide.git#32e6b5fe5ba9e1ea3e68da882550005122a11d22"
+dependencies = [
+ "digest_auth",
+ "hex",
+ "monero-rpc 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
+ "simple-request",
+ "tokio",
  "zeroize",
 ]
 
@@ -6609,6 +6805,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typeshare",
+ "url",
  "uuid",
 ]
 
@@ -9785,6 +9982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10021,6 +10228,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simple-request"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249660bdb65234c11f0eb69c0680096d8cc116897dbbeb8503269e469aad2fff"
+dependencies = [
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10200,6 +10421,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -10485,6 +10712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "std-shims"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fbb9ed849fede2765386134c64bc8984081e8c8408bc9201b99c6e3143ec5e7"
+dependencies = [
+ "hashbrown 0.14.5",
+ "rustversion",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10661,9 +10899,11 @@ dependencies = [
  "moka",
  "monero",
  "monero-harness",
- "monero-rpc",
+ "monero-rpc 0.1.0",
+ "monero-rpc 0.1.0 (git+https://github.com/monero-oxide/monero-oxide.git)",
  "monero-rpc-pool",
  "monero-seed",
+ "monero-simple-request-rpc",
  "monero-sys",
  "once_cell",
  "pem",

--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -73,9 +73,9 @@ impl<'c> Monero {
 
         let daemon = {
             let monerod_port = monerod_container.get_host_port_ipv4(RPC_PORT);
-            let monerod_url = format!("http://127.0.0.1:{}", monerod_port);
             Daemon {
-                address: monerod_url,
+                hostname: "127.0.0.1".to_string(),
+                port: monerod_port,
                 ssl: false,
             }
         };
@@ -83,13 +83,19 @@ impl<'c> Monero {
         {
             let client = reqwest::Client::new();
             let response = client
-                .get(format!("{}/get_info", &daemon.address))
+                .get(format!(
+                    "http://{}:{}/get_info",
+                    daemon.hostname, daemon.port
+                ))
                 .send()
                 .await?;
             tracing::debug!("Monerod response at /get_info: {:?}", response.status());
 
             let response = client
-                .get(format!("{}/json_rpc", &daemon.address))
+                .get(format!(
+                    "http://{}:{}/json_rpc",
+                    daemon.hostname, daemon.port
+                ))
                 .send()
                 .await?;
             tracing::debug!(

--- a/monero-sys/Cargo.toml
+++ b/monero-sys/Cargo.toml
@@ -15,6 +15,7 @@ swap-serde = { path = "../swap-serde" }
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
 tracing = { workspace = true }
 typeshare = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -32,6 +32,7 @@ use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
+use url::Url;
 
 use bridge::ffi::{self, TransactionHistory};
 use typeshare::typeshare;
@@ -146,8 +147,49 @@ pub struct TxReceipt {
 /// A remote node to connect to.
 #[derive(Debug, Clone, Default)]
 pub struct Daemon {
-    pub address: String,
+    pub hostname: String,
+    pub port: u16,
     pub ssl: bool,
+}
+
+impl Display for Daemon {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let url: Url = self.clone().into();
+        write!(f, "{}", url.to_string())
+    }
+}
+
+impl TryFrom<String> for Daemon {
+    type Error = anyhow::Error;
+
+    fn try_from(address: String) -> Result<Self, Self::Error> {
+        let url = Url::parse(&address).context("Failed to parse daemon URL")?;
+
+        let hostname = url
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("No hostname found in URL"))?
+            .to_string();
+
+        let port = url
+            .port()
+            .ok_or_else(|| anyhow::anyhow!("No port found in URL"))?;
+
+        let ssl = url.scheme() == "https";
+
+        Ok(Daemon {
+            hostname,
+            port,
+            ssl,
+        })
+    }
+}
+
+impl Into<Url> for Daemon {
+    fn into(self) -> Url {
+        let scheme = if self.ssl { "https" } else { "http" };
+        Url::parse(&format!("{}://{}:{}", scheme, self.hostname, self.port))
+            .expect("Valid URL from daemon components")
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -504,7 +546,7 @@ impl WalletHandle {
         self.call(move |wallet| wallet.synchronized()).await
     }
 
-    /// Get the restore height of the wallet.
+    /// Set the restore height of the wallet.
     pub async fn set_restore_height(&self, height: u64) -> anyhow::Result<()> {
         self.call(move |wallet| wallet.set_restore_height(height))
             .await
@@ -883,7 +925,8 @@ impl WalletHandle {
                 let mut manager = WalletManager::new(
                     // Dummy daemon address
                     Daemon {
-                        address: "localhost:18081".to_string(),
+                        hostname: "localhost".to_string(),
+                        port: 18081,
                         ssl: false,
                     },
                     &wallet_name,
@@ -993,7 +1036,7 @@ impl WalletManager {
             inner: RawWalletManager::new(manager),
         };
 
-        manager.set_daemon_address(&daemon.address);
+        manager.set_daemon_address(&daemon);
 
         Ok(manager)
     }
@@ -1243,7 +1286,8 @@ impl WalletManager {
     }
 
     /// Set the address of the remote node ("daemon").
-    fn set_daemon_address(&mut self, address: &str) {
+    fn set_daemon_address(&mut self, daemon: &Daemon) {
+        let address = format!("{}:{}", daemon.hostname, daemon.port);
         tracing::debug!(%address, "Updating wallet manager's remote node");
 
         let_cxx_string!(address = address);
@@ -1385,7 +1429,7 @@ impl FfiWallet {
             backoff(None, None),
             || {
                 wallet
-                    .init(&daemon.address, daemon.ssl)
+                    .init(&daemon)
                     .context("Failed to initialize wallet")
                     .map_err(backoff::Error::transient)
             },
@@ -1440,7 +1484,7 @@ impl FfiWallet {
 
     pub fn set_daemon(&mut self, daemon: &Daemon) -> anyhow::Result<()> {
         let ssl = daemon.ssl;
-        let address = daemon.address.clone();
+        let address = format!("{}:{}", daemon.hostname, daemon.port);
 
         tracing::debug!(%address, %ssl, "Setting daemon address");
 
@@ -1465,8 +1509,9 @@ impl FfiWallet {
 
     /// Initialize the wallet and download initial values from the remote node.
     /// Does not actuallyt sync the wallet, use any of the refresh methods to do that.
-    fn init(&mut self, daemon_address: &str, ssl: bool) -> anyhow::Result<()> {
-        tracing::debug!(%daemon_address, %ssl, "Initializing wallet");
+    fn init(&mut self, daemon: &Daemon) -> anyhow::Result<()> {
+        let daemon_address = format!("{}:{}", daemon.hostname, daemon.port);
+        tracing::debug!(%daemon_address, ssl=%daemon.ssl, "Initializing wallet");
 
         let_cxx_string!(daemon_address = daemon_address);
         let_cxx_string!(daemon_username = "");
@@ -1482,7 +1527,7 @@ impl FfiWallet {
                 0,
                 &daemon_username,
                 &daemon_password,
-                ssl,
+                daemon.ssl,
                 false,
                 &proxy_address,
             )

--- a/swap-asb/src/main.rs
+++ b/swap-asb/src/main.rs
@@ -72,19 +72,30 @@ trait IntoDaemon {
 
 impl IntoDaemon for url::Url {
     fn into_daemon(self) -> Result<Daemon> {
-        let address = self.to_string();
+        let hostname = self
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("No hostname found in URL"))?
+            .to_string();
+
+        let port = self
+            .port()
+            .ok_or_else(|| anyhow::anyhow!("No port found in URL"))?;
+
         let ssl = self.scheme() == "https";
 
-        Ok(Daemon { address, ssl })
+        Ok(Daemon {
+            hostname,
+            port,
+            ssl,
+        })
     }
 }
 
 impl IntoDaemon for monero_rpc_pool::ServerInfo {
     fn into_daemon(self) -> Result<Daemon> {
-        let address = format!("http://{}:{}", self.host, self.port);
-
         Ok(Daemon {
-            address,
+            hostname: self.host,
+            port: self.port,
             ssl: false,
         })
     }

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -100,6 +100,10 @@ uuid = { workspace = true, features = ["serde"] }
 void = "1"
 zeroize = "1.8.1"
 
+# monero-oxide
+monero-oxide-rpc = { git = "https://github.com/monero-oxide/monero-oxide.git", package = "monero-rpc" }
+monero-simple-request-rpc = { git = "https://github.com/monero-oxide/monero-oxide.git" }
+
 [target.'cfg(not(windows))'.dependencies]
 tokio-tar = "0.3"
 

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -441,10 +441,7 @@ impl ContextBuilder {
         };
 
         // Create a daemon struct for the monero wallet based on the node address
-        let daemon = monero_sys::Daemon {
-            address: monero_node_address,
-            ssl: false,
-        };
+        let daemon = monero_sys::Daemon::try_from(monero_node_address)?;
 
         // Prompt the user to open/create a Monero wallet
         let (wallet, seed) = open_monero_wallet(
@@ -665,31 +662,12 @@ impl Context {
                 let pool_url: String = server_info.clone().into();
                 tracing::info!("Switching to Monero RPC pool: {}", pool_url);
 
-                monero_sys::Daemon {
-                    address: pool_url,
-                    ssl: false,
-                }
+                monero_sys::Daemon::try_from(pool_url)?
             }
             MoneroNodeConfig::SingleNode { url } => {
                 tracing::info!("Switching to single Monero node: {}", url);
 
-                // Parse the URL to determine SSL and address
-                let (address, ssl) = if url.starts_with("https://") {
-                    (
-                        url.strip_prefix("https://").unwrap_or(&url).to_string(),
-                        true,
-                    )
-                } else if url.starts_with("http://") {
-                    (
-                        url.strip_prefix("http://").unwrap_or(&url).to_string(),
-                        false,
-                    )
-                } else {
-                    // Default to HTTP if no protocol specified
-                    (url, false)
-                };
-
-                monero_sys::Daemon { address, ssl }
+                monero_sys::Daemon::try_from(url.clone())?
             }
         };
 

--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -10,6 +10,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use crate::common::throttle::{throttle, Throttle};
 use anyhow::{Context, Result};
 use monero::{Address, Network};
+use monero_simple_request_rpc::SimpleRequestRpc;
 use monero_sys::WalletEventListener;
 pub use monero_sys::{Daemon, WalletHandle as Wallet, WalletHandleListener};
 use tokio::sync::RwLock;
@@ -30,7 +31,7 @@ pub struct Wallets {
     /// The network we're on.
     network: Network,
     /// The monero node we connect to.
-    daemon: Arc<RwLock<Daemon>>,
+    daemon: Arc<RwLock<(Daemon, SimpleRequestRpc)>>,
     /// Keep the main wallet open and synced.
     main_wallet: Arc<Wallet>,
     /// Since Network::Regtest isn't a thing we have to use an extra flag.
@@ -276,7 +277,8 @@ impl Wallets {
                 .await;
         }
 
-        let daemon = Arc::new(RwLock::new(daemon));
+        let rpc_client = SimpleRequestRpc::new(format!("{}", daemon)).await?;
+        let daemon = Arc::new(RwLock::new((daemon, rpc_client)));
 
         let wallets = Self {
             wallet_dir,
@@ -326,7 +328,8 @@ impl Wallets {
                 .await;
         }
 
-        let daemon = Arc::new(RwLock::new(daemon));
+        let rpc_client = SimpleRequestRpc::new(format!("{}", daemon)).await?;
+        let daemon = Arc::new(RwLock::new((daemon, rpc_client)));
 
         let wallets = Self {
             wallet_dir,
@@ -343,6 +346,15 @@ impl Wallets {
         let _ = wallets.record_wallet_access(&wallet_path).await;
 
         Ok(wallets)
+    }
+
+    pub async fn direct_rpc_block_height(&self) -> Result<u64> {
+        use monero_oxide_rpc::Rpc;
+        let (_, rpc_client) = self.daemon.read().await.clone();
+
+        let height = rpc_client.get_height().await?;
+
+        Ok(height as u64)
     }
 
     /// Open the lock wallet of a specific swap.
@@ -366,13 +378,9 @@ impl Wallets {
         let filename = swap_id.to_string();
         let wallet_path = self.wallet_dir.join(&filename).display().to_string();
 
-        let blockheight = self
-            .main_wallet
-            .blockchain_height()
-            .await
-            .context("Couldn't fetch blockchain height")?;
+        let blockheight = self.direct_rpc_block_height().await?;
 
-        let daemon = self.daemon.read().await.clone();
+        let (daemon, _) = self.daemon.read().await.clone();
 
         let wallet = Wallet::open_or_create_from_keys(
             wallet_path.clone(),
@@ -404,6 +412,8 @@ impl Wallets {
             .scan_transaction(tx_lock_id.0.clone())
             .await
             .context("Couldn't import Monero lock transaction")?;
+
+        wallet.set_restore_height(blockheight).await?;
 
         Ok(Arc::new(wallet))
     }
@@ -470,7 +480,8 @@ impl Wallets {
     pub async fn change_monero_node(&self, new_daemon: Daemon) -> Result<()> {
         {
             let mut daemon = self.daemon.write().await;
-            *daemon = new_daemon.clone();
+            let rpc_client = SimpleRequestRpc::new(format!("{}", new_daemon)).await?;
+            *daemon = (new_daemon.clone(), rpc_client);
         }
 
         self.main_wallet

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -613,13 +613,6 @@ impl State3 {
             .await
             .context(format!("Failed to open/create swap wallet `{}`", swap_id))?;
 
-        // Update blockheight to ensure that the wallet knows the funds are unlocked
-        tracing::debug!(%swap_id, "Updating temporary Monero wallet's blockheight");
-        let _ = swap_wallet
-            .blockchain_height()
-            .await
-            .context("Couldn't get Monero blockheight")?;
-
         tracing::debug!(%swap_id, "Sweeping Monero to redeem address");
         let main_address = monero_wallet.main_wallet().await.main_address().await;
 

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -761,13 +761,6 @@ impl State5 {
             .await
             .context("Failed to open Monero wallet")?;
 
-        // Update blockheight to ensure that the wallet knows the funds are unlocked
-        tracing::debug!(%swap_id, "Updating temporary Monero wallet's blockheight");
-        let _ = wallet
-            .blockchain_height()
-            .await
-            .context("Couldn't get Monero blockheight")?;
-
         tracing::debug!(%swap_id, receive_address=?monero_receive_pool, "Sweeping Monero to receive address");
 
         let main_address = monero_wallet.main_wallet().await.main_address().await;

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -49,6 +49,10 @@ where
     F: Future<Output = Result<()>>,
     C: GetConfig,
 {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install default rustls provider");
+
     let cli = Cli::default();
 
     tracing_subscriber::fmt()
@@ -304,7 +308,8 @@ async fn init_test_wallets(
         .map_to_host_port_ipv4(image::RPC_PORT)
         .expect("rpc port should be mapped to some external port");
     let monero_daemon = Daemon {
-        address: format!("http://127.0.0.1:{}", monerod_port),
+        hostname: "127.0.0.1".to_string(),
+        port: monerod_port,
         ssl: false,
     };
 


### PR DESCRIPTION
Now fails with:

```
2025-08-25T20:58:26.399315Z DEBUG monero_sys: Initialized wallet, setting daemon address
2025-08-25T20:58:26.399323Z DEBUG monero_sys: Setting daemon address address=http://127.0.0.1:32827 ssl=false
2025-08-25T20:58:26.399355Z  INFO monero_cpp: setting daemon to http://127.0.0.1:32827 wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="bool tools::wallet2::set_daemon(std::string, boost::optional<epee::net_utils::http::login>, bool, epee::net_utils::ssl_options_t, const std::string &)"
2025-08-25T20:58:26.399374Z  INFO monero_cpp: [PARSE URI] regex not matched for uri: ^(([^:]*?)://)?(\[(.*)\](:(\d+))?)(.*)? wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="bool epee::net_utils::parse_url_ipv6(const std::string, http::url_content &)"
2025-08-25T20:58:26.402408Z  INFO monero_cpp: Generating SSL certificate wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="bool epee::net_utils::create_rsa_ssl_certificate(EVP_PKEY *&, X509 *&)"
2025-08-25T20:58:26.484589Z DEBUG swap::monero::wallet: Opened temporary Monero wallet, loading lock transaction swap_id=ecc331e5-7c79-4911-b373-cc2f7c9bbd48
2025-08-25T20:58:26.625838Z  WARN monero_cpp: SSL peer has not been verified wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="auto epee::net_utils::ssl_options_t::configure(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &, boost::asio::ssl::stream_base::handshake_type, const std::string &)::(anonymous class)::operator()(const bool, boost::asio::ssl::verify_context &) const"
2025-08-25T20:58:26.625885Z  WARN monero_cpp: SSL peer has not been verified wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="auto epee::net_utils::ssl_options_t::configure(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &, boost::asio::ssl::stream_base::handshake_type, const std::string &)::(anonymous class)::operator()(const bool, boost::asio::ssl::verify_context &) const"
2025-08-25T20:58:26.695286Z  WARN monero_cpp: Re-processing wallet's existing txs (if any) starting from height 150 wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::wallet2::scan_tx(const std::unordered_set<crypto::hash> &)"
2025-08-25T20:58:26.695395Z  WARN monero_cpp: Detaching blockchain on height 150 wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="wallet2::detached_blockchain_data tools::wallet2::detach_blockchain(uint64_t, std::map<std::pair<uint64_t, uint64_t>, size_t> *)"
2025-08-25T20:58:26.695618Z  WARN monero_cpp: Detached blockchain on height 150, transfers detached 1, blocks detached 1 wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="wallet2::detached_blockchain_data tools::wallet2::detach_blockchain(uint64_t, std::map<std::pair<uint64_t, uint64_t>, size_t> *)"
2025-08-25T20:58:26.695706Z  WARN monero_cpp: Processing 1 txs, re-processing 0 txs wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::wallet2::process_scan_txs(const tx_entry_data &, const tx_entry_data &, const std::unordered_set<crypto::hash> &, detached_blockchain_data &)"
2025-08-25T20:58:26.701873Z  WARN monero_cpp: Received money: 1.000000000000, with tx: <c272388d460f9c3c5ed174f221b681f7778f87cd529ec345d48e70507f1ee552> wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::wallet2::process_new_transaction(const crypto::hash &, const cryptonote::transaction &, const std::vector<uint64_t> &, uint64_t, uint8_t, uint64_t, bool, bool, bool, const tx_cache_data &, std::map<std::pair<uint64_t, uint64_t>, size_t> *, bool)"
2025-08-25T20:58:26.702012Z  INFO monero_cpp: Consider using subaddresses instead of encrypted payment IDs wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::wallet2::process_new_transaction(const crypto::hash &, const cryptonote::transaction &, const std::vector<uint64_t> &, uint64_t, uint8_t, uint64_t, bool, bool, bool, const tx_cache_data &, std::map<std::pair<uint64_t, uint64_t>, size_t> *, bool)"
2025-08-25T20:58:26.702788Z  WARN monero_cpp: Done processing 1 txs and re-processing 0 txs wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::wallet2::process_scan_txs(const tx_entry_data &, const tx_entry_data &, const std::unordered_set<crypto::hash> &, detached_blockchain_data &)"
2025-08-25T20:58:26.702838Z  WARN monero_cpp: Re-attaching 1 blocks wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::reattach_blockchain(hashchain &, wallet2::detached_blockchain_data &)"
2025-08-25T20:58:26.703028Z DEBUG swap::protocol::bob::state: Sweeping Monero to receive address swap_id=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 receive_address=MoneroAddressPool([LabeledMoneroAddress { address: Some(Address { network: Mainnet, addr_type: Standard, public_spend: 7c0f602cc876b673d4406aacd6b7c14faff3f787816e73431f56a521548b7c2f, public_view: 5430c5e58cfe838ce11f0e04285ac8903f04e0d66ccb42e5fb5068f782c32667 }), percentage: 1, label: "user address" }])
2025-08-25T20:58:26.703594Z DEBUG monero_sys: Sweeping multi addresses=[Address { network: Mainnet, addr_type: Standard, public_spend: 7c0f602cc876b673d4406aacd6b7c14faff3f787816e73431f56a521548b7c2f, public_view: 5430c5e58cfe838ce11f0e04285ac8903f04e0d66ccb42e5fb5068f782c32667 }] percentages=[1.0]
2025-08-25T20:58:26.703688Z  WARN monero_sys: STARTED MULTI SWEEP
2025-08-25T20:58:26.703702Z  INFO monero_sys: Sweeping funds to 1 addresses, refreshing wallet first
2025-08-25T20:58:26.705687Z  INFO monero_cpp: Refresh done, blocks received: 0, balance (all accounts): 1.000000000000, unlocked: 0.000000000000 wallet=ecc331e5-7c79-4911-b373-cc2f7c9bbd48 function="void tools::wallet2::refresh(bool, uint64_t, uint64_t &, bool &, bool, bool, uint64_t)"
2025-08-25T20:58:26.706014Z  INFO monero_sys: Wallet handle dropped, closing wallet and exiting thread wallet=/var/folders/tv/4vfzf9m952l42zwjyg3qxtzh0000gn/T/.tmpMVROO2/bob-monero-wallets/ecc331e5-7c79-4911-b373-cc2f7c9bbd48
2025-08-25T20:58:26.706013Z  WARN swap::common: Failed operation `Redeeming Monero`, retrying in 9 seconds error=Failed to redeem Monero

Caused by:
    Zero balance to distribute
```

Update: I fixed the issue above by setting the restore height after importing the transaction.