### PR TITLE
Update build-release-binaries.yml to add '-controller' suffix to asb-controller build

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -173,8 +173,8 @@ jobs:
           file: ./swap-controller/Dockerfile
           push: true
           tags: |
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ github.event.release.tag_name }}
-            ${{ env.DOCKER_IMAGE_NAME }}:latest
+            ${{ env.DOCKER_IMAGE_NAME }}-controller:${{ github.event.release.tag_name }}
+            ${{ env.DOCKER_IMAGE_NAME }}-controller:latest
         if: steps.docker_tags.outputs.preview == 'false'
 
       - name: Build and push Docker image without latest tag (preview release) (asb-controller)
@@ -183,5 +183,5 @@ jobs:
           context: .
           file: ./swap-controller/Dockerfile
           push: true
-          tags: ${{ env.DOCKER_IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          tags: ${{ env.DOCKER_IMAGE_NAME }}-controller:${{ github.event.release.tag_name }}
         if: steps.docker_tags.outputs.preview == 'true'


### PR DESCRIPTION
At current it seams that the 'asb' package in the github registry is actually the 'asb-controller' package.

From what I can see it seems as if the 'asb-controller' package build is overriding the 'asb' package