### PR TITLE
 fix: mount apt cache as locked in docker buildkit

### DIFF
--- a/swap-asb/Dockerfile
+++ b/swap-asb/Dockerfile
@@ -10,9 +10,8 @@ FROM ubuntu:24.04@sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acd
 # See .github/actions/set-monero-env/action.yml for required dependencies
 # The `--mount` allows us to agressively cache this step.
 ENV DEBIAN_FRONTEND=noninteractive
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
-    apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \    apt-get update && \
     apt-get install -y --allow-change-held-packages \
     autoconf \
     # Left out as we are not compiling for Windows in this Dockerfile
@@ -95,8 +94,8 @@ FROM ubuntu:24.04@sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acd
 
 # Install native root certificates
 ENV DEBIAN_FRONTEND=noninteractive
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     apt-get install -y ca-certificates && \
     update-ca-certificates

--- a/swap-controller/Dockerfile
+++ b/swap-controller/Dockerfile
@@ -14,8 +14,8 @@ FROM debian:bookworm@sha256:b6507e340c43553136f5078284c8c68d86ec8262b1724dde73c3
 
 # Install native root certificates
 ENV DEBIAN_FRONTEND=noninteractive
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     apt-get install -y ca-certificates && \
     update-ca-certificates


### PR DESCRIPTION
See https://docs.docker.com/build/cache/optimize/#use-cache-mounts