### PR TITLE
fix(asb): Wait before re-trying rendezvous register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - GUI + SWAP + ASB: Upgrade arti (tor library) to 1.5.0. This might improve connectivity reliability.
+- ASB: Fix an issue where we would not wait between re-dials of rendezvous nodes.
 
 ## [3.0.4] - 2025-09-26
 

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -12,7 +12,6 @@ use crate::protocol::alice::{AliceState, State3, Swap, TipConfig};
 use crate::protocol::{Database, State};
 use crate::{bitcoin, monero};
 use anyhow::{anyhow, Context, Result};
-use bdk_chain::rusqlite::ffi::SQLITE_TRACE_CLOSE;
 use futures::future;
 use futures::future::{BoxFuture, FutureExt};
 use futures::stream::{FuturesUnordered, StreamExt};

--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -300,6 +300,8 @@ pub mod rendezvous {
     pub struct Behaviour {
         inner: libp2p::rendezvous::client::Behaviour,
         rendezvous_nodes: Vec<RendezvousNode>,
+        // always use schedule_dial to schedule a dial
+        // do not insert directly into this future
         to_dial: FuturesUnordered<BoxFuture<'static, PeerId>>,
         backoffs: HashMap<PeerId, ExponentialBackoff>,
     }
@@ -353,6 +355,10 @@ pub mod rendezvous {
                         max_interval: Duration::from_secs(5 * 60),
                         // Never give up
                         max_elapsed_time: None,
+                        // We retry aggressively. We begin with 50ms and increase by 10% per retry.
+                        multiplier: 0.1f64,
+                        initial_interval: Duration::from_millis(50),
+                        current_interval: Duration::from_millis(50),
                         ..ExponentialBackoff::default()
                     },
                 );

--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -356,7 +356,7 @@ pub mod rendezvous {
                         // Never give up
                         max_elapsed_time: None,
                         // We retry aggressively. We begin with 50ms and increase by 10% per retry.
-                        multiplier: 0.1f64,
+                        multiplier: 1.1f64,
                         initial_interval: Duration::from_millis(50),
                         current_interval: Duration::from_millis(50),
                         ..ExponentialBackoff::default()

--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -343,7 +343,7 @@ pub mod rendezvous {
     impl Behaviour {
         pub fn new(identity: identity::Keypair, rendezvous_nodes: Vec<RendezvousNode>) -> Self {
             let mut backoffs = HashMap::new();
-            
+
             // Initialize backoff for each rendezvous node
             for node in &rendezvous_nodes {
                 backoffs.insert(
@@ -357,7 +357,7 @@ pub mod rendezvous {
                     },
                 );
             }
-            
+
             Self {
                 inner: libp2p::rendezvous::client::Behaviour::new(identity),
                 rendezvous_nodes,
@@ -378,16 +378,30 @@ pub mod rendezvous {
 
         /// Schedules a dial to a peer with exponential backoff delay.
         fn schedule_dial(&mut self, peer_id: PeerId) {
-            let backoff = self.backoffs.get_mut(&peer_id).expect("Backoff should exist for all rendezvous nodes");
-            let delay = backoff.next_backoff().expect("Backoff should never run out");
-            
+            let backoff = self
+                .backoffs
+                .get_mut(&peer_id)
+                .expect("Backoff should exist for all rendezvous nodes");
+            let delay = backoff
+                .next_backoff()
+                .expect("Backoff should never run out");
+
             // Create a future that sleeps and then returns the peer_id
             let future = async move {
                 tokio::time::sleep(delay).await;
                 peer_id
             };
-            
+
             self.to_dial.push(future.boxed());
+
+            // Set the connection status to Dialling
+            if let Some(node) = self
+                .rendezvous_nodes
+                .iter_mut()
+                .find(|node| node.peer_id == peer_id)
+            {
+                node.set_connection(ConnectionStatus::Dialling);
+            }
         }
     }
 
@@ -443,8 +457,8 @@ pub mod rendezvous {
 
         fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
             match event {
-                FromSwarm::ConnectionEstablished(peer) => {
-                    let peer_id = peer.peer_id;
+                FromSwarm::ConnectionEstablished(connection) => {
+                    let peer_id = connection.peer_id;
 
                     // Find the rendezvous node that matches the peer id, else do nothing.
                     if let Some(index) = self
@@ -472,8 +486,9 @@ pub mod rendezvous {
                         }
                     }
                 }
-                FromSwarm::ConnectionClosed(peer) => {
-                    let peer_id = peer.peer_id;
+                FromSwarm::ConnectionClosed(connection) => {
+                    let peer_id = connection.peer_id;
+
                     // Update the connection status of the rendezvous node that disconnected.
                     if let Some(node) = self
                         .rendezvous_nodes
@@ -484,9 +499,9 @@ pub mod rendezvous {
                         self.schedule_dial(peer_id);
                     }
                 }
-                FromSwarm::DialFailure(peer) => {
+                FromSwarm::DialFailure(dial_failure) => {
                     // Update the connection status of the rendezvous node that failed to connect.
-                    if let Some(peer_id) = peer.peer_id {
+                    if let Some(peer_id) = dial_failure.peer_id {
                         if let Some(node) = self
                             .rendezvous_nodes
                             .iter_mut()
@@ -517,7 +532,9 @@ pub mod rendezvous {
             cx: &mut Context<'_>,
         ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
             // Check if we need to dial a peer
-            if let Poll::Ready(Some(peer_id)) = self.to_dial.poll_next_unpin(cx) {                
+            if let Poll::Ready(Some(peer_id)) = self.to_dial.poll_next_unpin(cx) {
+                // This should be redundant as this is already set in the schedule_dial function
+                // we still do it here to be safe
                 if let Some(node) = self
                     .rendezvous_nodes
                     .iter_mut()
@@ -525,7 +542,7 @@ pub mod rendezvous {
                 {
                     node.set_connection(ConnectionStatus::Dialling);
                 }
-                
+
                 return Poll::Ready(ToSwarm::Dial {
                     opts: DialOpts::peer_id(peer_id)
                         .addresses(vec![self
@@ -541,7 +558,7 @@ pub mod rendezvous {
                         .build(),
                 });
             }
-            
+
             // Check the status of each rendezvous node
             for i in 0..self.rendezvous_nodes.len() {
                 let connection_status = self.rendezvous_nodes[i].connection_status.clone();
@@ -569,10 +586,10 @@ pub mod rendezvous {
                                 }
                                 ConnectionStatus::Disconnected => {
                                     let peer_id = self.rendezvous_nodes[i].peer_id;
-                                    self.schedule_dial(peer_id);
                                     self.rendezvous_nodes[i].set_registration(
                                         RegistrationStatus::RegisterOnNextConnection,
                                     );
+                                    self.schedule_dial(peer_id);
                                 }
                                 ConnectionStatus::Dialling => {}
                             }


### PR DESCRIPTION
Untested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce exponential backoff-based re-dial scheduling for rendezvous nodes with reset on success, and note the fix in the changelog.
> 
> - **ASB Networking (rendezvous)**:
>   - Introduce exponential backoff for re-dials via `backoff::ExponentialBackoff` and a `schedule_dial` helper.
>   - Replace `VecDeque` with `FuturesUnordered` for delayed dial scheduling; track per-peer backoffs in a `HashMap`.
>   - Reset backoff on successful connection; automatically re-schedule dials on disconnect or dial failure.
>   - Adjust polling to emit dials when scheduled and refine registration flow to re-register upon reconnect or re-schedule when disconnected.
> - **Changelog**:
>   - Add Unreleased note: `ASB` waits between re-dials of rendezvous nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d42814726ac33fa5976d82c18793037426eb3fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->