### PR TITLE
fix(asb): serialize Monero locks and refund unfundable swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - GUI: Support outbound connections to makers through libp2p circuit relays.
+- ASB: Fix concurrent swaps selecting the same Monero output when building their lock transactions,
+  which turned the losing swap's lock transaction into a permanent double-spend
+  and left the taker's swap stuck until it refunded.
+  A concurrent swap the maker can no longer fund is now refunded early,
+  instead of building a doomed lock transaction that wedges the swap.
 
 ## [4.14.0] - 2026-08-22
 

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -10,6 +10,7 @@ use swap_env::env::Config;
 pub use swap_machine::alice::*;
 use uuid::Uuid;
 
+pub mod lock_phase;
 pub mod swap;
 
 pub struct Swap {

--- a/swap/src/protocol/alice/lock_phase.rs
+++ b/swap/src/protocol/alice/lock_phase.rs
@@ -1,0 +1,202 @@
+//! Serialization of the Monero lock phase across concurrent swaps.
+//!
+//! wallet2 only marks an output spent once its lock transaction is relayed and
+//! monero-sys has no reserve API, so two overlapping swaps can pick the same
+//! output and the loser's lock transaction becomes a permanent double-spend
+//! that monerod rejects forever. [`MoneroLockPhase`] hands out one process-wide
+//! permit for the phase; each swap tracks its participation through a
+//! [`LockPhaseSession`] so the state machine only has to say whether its
+//! current state is inside the phase.
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::{Mutex, MutexGuard};
+
+/// Process-wide serialization of the Monero lock phase.
+///
+/// The phase spans output selection (`BtcLocked`) through the first relay of
+/// the lock transaction (`XmrLockTransactionConstructed`).
+pub struct MoneroLockPhase {
+    mutex: Mutex<()>,
+    max_hold: Duration,
+}
+
+impl MoneroLockPhase {
+    /// A lock phase whose sessions may hold the permit for at most `max_hold`.
+    pub fn new(max_hold: Duration) -> Self {
+        Self {
+            mutex: Mutex::new(()),
+            max_hold,
+        }
+    }
+
+    /// Start tracking one swap's participation in the phase.
+    pub fn session(&self) -> LockPhaseSession<'_> {
+        LockPhaseSession {
+            phase: self,
+            held: None,
+            abandoned: false,
+        }
+    }
+}
+
+/// One swap's view of the serialized phase, held on `run_until`'s stack because
+/// construct and publish are separate states with a persist in between.
+pub struct LockPhaseSession<'a> {
+    phase: &'a MoneroLockPhase,
+    held: Option<(MutexGuard<'a, ()>, Instant)>,
+    /// Set once this swap exhausts `max_hold` and continues unserialized.
+    abandoned: bool,
+}
+
+impl LockPhaseSession<'_> {
+    /// Bring the session in line with whether the swap's current state is
+    /// inside the phase: acquire the process-wide permit on entry (unless this
+    /// swap already overstayed and continues unserialized), release it on exit.
+    pub async fn sync_to(&mut self, in_phase: bool) {
+        if !in_phase {
+            self.release();
+        } else if self.held.is_none() && !self.abandoned {
+            let guard = self.phase.mutex.lock().await;
+            tracing::debug!("Entered the serialized Monero lock phase");
+            self.held = Some((guard, Instant::now()));
+        }
+    }
+
+    /// Remaining time this swap may keep the permit, or `None` when it is not
+    /// holding it (never entered, already released, or abandoned).
+    pub fn deadline(&self) -> Option<Duration> {
+        self.held
+            .as_ref()
+            .map(|(_, since)| self.phase.max_hold.saturating_sub(since.elapsed()))
+    }
+
+    /// Whether this session currently holds the process-wide permit.
+    pub fn holds_permit(&self) -> bool {
+        self.held.is_some()
+    }
+
+    /// Leave the phase normally: release the permit and re-arm the session for
+    /// a future phase.
+    pub fn release(&mut self) {
+        if self.held.take().is_some() {
+            tracing::debug!("Left the serialized Monero lock phase");
+        }
+        self.abandoned = false;
+    }
+
+    /// Give up the permit after overstaying the deadline. The swap continues
+    /// unserialized until it leaves the phase, which re-arms it via
+    /// [`LockPhaseSession::release`].
+    pub fn abandon(&mut self) {
+        self.held = None;
+        self.abandoned = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WAIT: Duration = Duration::from_millis(50);
+
+    #[tokio::test]
+    async fn phase_is_exclusive_until_released() {
+        let phase = MoneroLockPhase::new(Duration::from_secs(60));
+
+        let mut first = phase.session();
+        first.sync_to(true).await;
+        assert!(first.holds_permit());
+
+        let mut second = phase.session();
+        assert!(
+            tokio::time::timeout(WAIT, second.sync_to(true))
+                .await
+                .is_err(),
+            "second session must wait while the first holds the permit"
+        );
+        assert!(!second.holds_permit());
+
+        first.release();
+        assert!(!first.holds_permit());
+
+        tokio::time::timeout(WAIT, second.sync_to(true))
+            .await
+            .expect("second session acquires once the first released");
+        assert!(second.holds_permit());
+    }
+
+    #[tokio::test]
+    async fn deadline_is_bounded_by_max_hold_and_none_when_not_held() {
+        let phase = MoneroLockPhase::new(Duration::from_secs(60));
+        let mut session = phase.session();
+
+        assert_eq!(session.deadline(), None);
+
+        session.sync_to(true).await;
+        let deadline = session.deadline().expect("held sessions have a deadline");
+        assert!(deadline <= Duration::from_secs(60));
+
+        session.sync_to(false).await;
+        assert_eq!(session.deadline(), None);
+    }
+
+    #[tokio::test]
+    async fn deadline_expires_to_zero() {
+        let phase = MoneroLockPhase::new(Duration::from_millis(5));
+        let mut session = phase.session();
+
+        session.sync_to(true).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(session.deadline(), Some(Duration::ZERO));
+    }
+
+    #[tokio::test]
+    async fn abandoned_session_continues_unserialized_until_it_leaves_the_phase() {
+        let phase = MoneroLockPhase::new(Duration::from_secs(60));
+
+        let mut wedged = phase.session();
+        wedged.sync_to(true).await;
+        wedged.abandon();
+        assert!(!wedged.holds_permit());
+        assert_eq!(wedged.deadline(), None);
+
+        // Still inside the phase: the session must not re-acquire...
+        tokio::time::timeout(WAIT, wedged.sync_to(true))
+            .await
+            .expect("an abandoned session never blocks");
+        assert!(!wedged.holds_permit());
+
+        // ...so another swap is free to take the permit meanwhile.
+        let mut other = phase.session();
+        tokio::time::timeout(WAIT, other.sync_to(true))
+            .await
+            .expect("the permit is free after an abandon");
+        assert!(other.holds_permit());
+        other.release();
+
+        // Leaving the phase re-arms the abandoned session for the next one.
+        wedged.sync_to(false).await;
+        tokio::time::timeout(WAIT, wedged.sync_to(true))
+            .await
+            .expect("a re-armed session acquires again");
+        assert!(wedged.holds_permit());
+    }
+
+    #[tokio::test]
+    async fn dropping_a_session_frees_the_permit() {
+        let phase = MoneroLockPhase::new(Duration::from_secs(60));
+
+        {
+            let mut held = phase.session();
+            held.sync_to(true).await;
+            assert!(held.holds_permit());
+        }
+
+        let mut next = phase.session();
+        tokio::time::timeout(WAIT, next.sync_to(true))
+            .await
+            .expect("dropping a holding session frees the permit");
+        assert!(next.holds_permit());
+    }
+}

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -1,12 +1,13 @@
 //! Run an XMR/BTC swap in the role of Alice.
 //! Alice holds XMR and wishes receive BTC.
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use crate::asb::{EventLoopHandle, LatestRate};
 use crate::common::retry;
 use crate::monero;
 use crate::monero::TransferProof;
+use crate::protocol::alice::lock_phase::MoneroLockPhase;
 use crate::protocol::alice::{AliceState, HermesFundingPolicy, Swap, TipConfig};
 use ::bitcoin::consensus::encode::serialize_hex;
 use anyhow::{Context, Result, bail};
@@ -21,6 +22,23 @@ use swap_machine::alice::State3;
 use tokio::select;
 use tokio::time::timeout;
 use uuid::Uuid;
+
+/// Serializes the Monero lock phase (output selection in `BtcLocked` through the first
+/// relay in `XmrLockTransactionConstructed`) across all swaps in the process. wallet2 only
+/// marks an output spent once its lock transaction is relayed and monero-sys has no reserve
+/// API, so without this two overlapping swaps pick the same output and the loser's lock
+/// transaction is a permanent double-spend that monerod rejects forever. Each swap tracks
+/// its participation through a session held on `run_until`'s stack because construct and
+/// publish are separate states.
+static MONERO_LOCK_PHASE: LazyLock<MoneroLockPhase> =
+    LazyLock::new(|| MoneroLockPhase::new(MONERO_LOCK_PHASE_MAX_HOLD));
+
+/// Maximum time a swap may hold [`MONERO_LOCK_PHASE`]. Past it a swap wedged on a rejected
+/// publish releases the guard and continues unserialized instead of starving the others.
+const MONERO_LOCK_PHASE_MAX_HOLD: Duration = Duration::from_secs(20 * 60);
+
+/// `.expect` message for the persist retry loop, which never stops retrying.
+const PERSIST_EXPECT: &str = "we never stop retrying to persist the latest Alice state";
 
 pub async fn run<LR>(swap: Swap, rate_service: LR) -> Result<AliceState>
 where
@@ -40,10 +58,23 @@ where
 {
     let mut current_state = swap.state;
 
+    // Tracks this swap's participation in the serialized Monero lock phase, across the
+    // separate `next_state` calls and the persist between them. See [`MONERO_LOCK_PHASE`].
+    let mut lock_phase = MONERO_LOCK_PHASE.session();
+
     while !swap_machine::alice::is_complete(&current_state) && !exit_early(&current_state) {
-        current_state = next_state(
+        lock_phase
+            .sync_to(in_monero_lock_phase(&current_state))
+            .await;
+
+        // While holding the permit, bound each step: the publish arm retries without a limit,
+        // and a wedged swap must not keep others from locking Monero. Cancelling is safe:
+        // no state is persisted and both arms are re-entrant.
+        let step_deadline = lock_phase.deadline();
+
+        let step = next_state(
             swap.swap_id,
-            current_state,
+            current_state.clone(),
             &mut swap.event_loop_handle,
             swap.bitcoin_wallet.clone(),
             swap.monero_wallet.clone(),
@@ -51,10 +82,27 @@ where
             swap.developer_tip.clone(),
             swap.hermes_funding_policy,
             rate_service.clone(),
-        )
-        .await?;
+        );
 
-        retry(
+        current_state = match step_deadline {
+            Some(deadline) => match timeout(deadline, step).await {
+                Ok(next) => next?,
+                Err(_) => {
+                    abandon_lock_phase(&current_state, &swap.monero_wallet).await;
+                    lock_phase.abandon();
+                    continue;
+                }
+            },
+            None => step.await?,
+        };
+
+        // Release before the persist: the persist retries without a limit and must not pin
+        // the process-wide permit.
+        if !in_monero_lock_phase(&current_state) {
+            lock_phase.release();
+        }
+
+        let persist = retry(
             "Persisting latest Alice state",
             || {
                 let db = swap.db.clone();
@@ -68,9 +116,24 @@ where
             },
             None,
             None,
-        )
-        .await
-        .expect("we never stop retrying to persist the latest Alice state");
+        );
+
+        // A persist of an in-phase state counts against the same deadline; past it we release
+        // the guard and finish the persist unserialized (the persist itself is never dropped).
+        match lock_phase.deadline() {
+            Some(remaining) => {
+                tokio::pin!(persist);
+                match timeout(remaining, &mut persist).await {
+                    Ok(persisted) => persisted.expect(PERSIST_EXPECT),
+                    Err(_) => {
+                        abandon_lock_phase(&current_state, &swap.monero_wallet).await;
+                        lock_phase.abandon();
+                        persist.await.expect(PERSIST_EXPECT);
+                    }
+                }
+            }
+            None => persist.await.expect(PERSIST_EXPECT),
+        }
     }
 
     Ok(current_state)
@@ -195,6 +258,35 @@ where
                         hermes_funding,
                         developer_tip.clone(),
                     )?;
+
+                    // Under MONERO_LOCK_PHASE, refuse to construct a lock the wallet cannot
+                    // fund. A concurrent swap that already locked its Monero has reduced the
+                    // spendable balance; without this guard wallet2 can still reselect the
+                    // sibling's freshly spent outputs, build a lock that double-spends, and then
+                    // wedge on a permanently rejected publish. A permanent error here routes to an
+                    // early Bitcoin refund (no Monero was locked, so it is safe) instead. This is a
+                    // best-effort guard bounded by how promptly the wallet reflects the sibling
+                    // spend; a fully reliable check would query the daemon for spent key images.
+                    let needed_pico = destinations
+                        .iter()
+                        .map(|(_, amount)| amount.as_pico())
+                        .sum::<u64>()
+                        .saturating_add(swap_core::monero::CONSERVATIVE_MONERO_FEE.as_pico());
+                    let unlocked_pico = monero_wallet
+                        .main_wallet()
+                        .await
+                        .unlocked_balance()
+                        .await
+                        .context("Failed to read unlocked Monero balance before constructing the lock transaction")
+                        .map_err(backoff::Error::transient)?
+                        .as_pico();
+                    if unlocked_pico < needed_pico {
+                        return Err(backoff::Error::permanent(anyhow::anyhow!(
+                            "Insufficient unlocked Monero to fund the lock transaction \
+                             ({unlocked_pico} < {needed_pico} piconero); a concurrent swap consumed \
+                             the shared balance, refunding this swap early"
+                        )));
+                    }
 
                     let constructed = monero_wallet
                         .construct_multi_destination_tx(&destinations)
@@ -1272,6 +1364,49 @@ async fn cancel_timelock_not_expired(
         state3.expired_timelocks(bitcoin_wallet).await?,
         ExpiredTimelocks::None { .. }
     ))
+}
+
+/// Whether `state` is inside the serialized Monero lock phase (see [`MONERO_LOCK_PHASE`]).
+fn in_monero_lock_phase(state: &AliceState) -> bool {
+    matches!(
+        state,
+        AliceState::BtcLocked { .. } | AliceState::XmrLockTransactionConstructed { .. }
+    )
+}
+
+/// Releases [`MONERO_LOCK_PHASE`] after a swap overstays its deadline while still holding a
+/// constructed lock transaction. If that transaction already reached the chain, scan it so
+/// wallet2 marks its outputs spent before the next swap constructs; otherwise the
+/// unserialized race returns for this one wedged swap. Bounded so an unresponsive daemon
+/// cannot extend the hold.
+async fn abandon_lock_phase(state: &AliceState, monero_wallet: &monero::Wallets) {
+    let AliceState::XmrLockTransactionConstructed { xmr_lock_tx, .. } = state else {
+        tracing::warn!("Monero lock phase exceeded its deadline; releasing the lock");
+        return;
+    };
+
+    let tx_hash = monero::TxHash::from_tx(xmr_lock_tx);
+    tracing::warn!(%tx_hash, "Monero lock phase exceeded its deadline; releasing the lock");
+
+    let scanned = timeout(Duration::from_secs(60), async {
+        if monero_wallet.is_transaction_present(&tx_hash).await? {
+            monero_wallet
+                .main_wallet()
+                .await
+                .scan_transaction(tx_hash.0.clone())
+                .await?;
+        }
+        anyhow::Ok(())
+    })
+    .await;
+
+    match scanned {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(%tx_hash, %error, "Failed to scan the lock transaction on release")
+        }
+        Err(_) => tracing::warn!(%tx_hash, "Timed out scanning the lock transaction on release"),
+    }
 }
 
 #[cfg(test)]

--- a/swap/tests/concurrent_bobs_insufficient_xmr.rs
+++ b/swap/tests/concurrent_bobs_insufficient_xmr.rs
@@ -1,0 +1,87 @@
+pub mod harness;
+
+use harness::SlowCancelConfig;
+use swap::asb::FixedRate;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+/// Two swaps run at once but the maker only holds enough Monero to fund ONE of
+/// them (two 1-XMR outputs, each swap needs ~1.02 XMR). The serialized lock
+/// phase must let the winner lock and make the loser fail CLEANLY at construct
+/// time (an early Bitcoin refund) instead of building a lock that double-spends
+/// the winner's inputs and then wedging on a permanently rejected publish.
+#[tokio::test]
+async fn concurrent_bobs_insufficient_xmr() {
+    harness::setup_test_funded(SlowCancelConfig, None, None, 2, |mut ctx| async move {
+        let (bob_swap_1, bob_join_handle_1) = ctx.bob_swap().await;
+        let bob_swap_1 = tokio::spawn(bob::run(bob_swap_1));
+        let alice_swap_1 = ctx.alice_next_swap().await;
+        let alice_swap_1 = tokio::spawn(alice::run(alice_swap_1, FixedRate::default()));
+
+        let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
+        let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));
+        let alice_swap_2 = ctx.alice_next_swap().await;
+        let alice_swap_2 = tokio::spawn(alice::run(alice_swap_2, FixedRate::default()));
+
+        let bob_state_1 = bob_swap_1.await??;
+        let bob_state_2 = bob_swap_2.await??;
+        let alice_state_1 = alice_swap_1.await??;
+        let alice_state_2 = alice_swap_2.await??;
+
+        bob_join_handle_1.abort();
+        bob_join_handle_2.abort();
+
+        let alices = [&alice_state_1, &alice_state_2];
+        let redeemed = alices
+            .iter()
+            .filter(|s| matches!(s, AliceState::BtcRedeemed))
+            .count();
+        // The un-fundable swap must refund cleanly. An early refund (construct
+        // failed, no Monero was locked) is the intended outcome; a plain refund
+        // is also acceptable, but the swap must reach a terminal refund state
+        // rather than wedge on a rejected double-spend publish.
+        let refunded = alices
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s,
+                    AliceState::BtcEarlyRefunded(_)
+                        | AliceState::SafelyAborted
+                        | AliceState::XmrRefunded { .. }
+                )
+            })
+            .count();
+        assert_eq!(redeemed, 1, "exactly one maker swap should lock and redeem");
+        assert_eq!(
+            refunded, 1,
+            "the un-fundable maker swap must refund cleanly, not wedge; got {alice_state_1} / {alice_state_2}"
+        );
+
+        let bobs = [&bob_state_1, &bob_state_2];
+        assert_eq!(
+            bobs.iter()
+                .filter(|s| matches!(s, BobState::XmrRedeemed { .. }))
+                .count(),
+            1,
+            "one taker should redeem XMR"
+        );
+        assert_eq!(
+            bobs.iter()
+                .filter(|s| {
+                    matches!(
+                        s,
+                        BobState::BtcEarlyRefunded { .. }
+                            | BobState::BtcEarlyRefundPublished { .. }
+                            | BobState::BtcRefunded { .. }
+                    )
+                })
+                .count(),
+            1,
+            "the other taker should get its Bitcoin refunded (early refund, since the maker never locked Monero)"
+        );
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -47,10 +47,11 @@ use uuid::Uuid;
 ///
 /// If use_subaddress is true, we will use a subaddress for the developer tip. We do this
 /// because using a subaddress changes things about the tx keys involved
-pub async fn setup_test<T, F, C>(
+pub async fn setup_test_funded<T, F, C>(
     _config: C,
     developer_tip_ratio: Option<(Decimal, bool)>,
     refund_policy: Option<RefundPolicy>,
+    alice_xmr_outputs: u64,
     testfn: T,
 ) where
     T: Fn(TestContext) -> F,
@@ -126,7 +127,7 @@ pub async fn setup_test<T, F, C>(
     };
 
     let alice_starting_balances =
-        StartingBalances::new(bitcoin::Amount::ZERO, xmr_amount, Some(10));
+        StartingBalances::new(bitcoin::Amount::ZERO, xmr_amount, Some(alice_xmr_outputs));
     let alice_seed = Seed::random().unwrap();
     let alice_db_path = NamedTempFile::new().unwrap().path().to_path_buf();
     let alice_config_path = alice_db_path.with_extension("config.toml");
@@ -295,6 +296,22 @@ ask_spread = "0"
     };
 
     testfn(test).await.unwrap()
+}
+
+/// Thin wrapper over [`setup_test_funded`] with the default maker Monero balance
+/// (ten 1-XMR outputs), used by every test that does not need to constrain how
+/// much unlocked XMR Alice holds.
+pub async fn setup_test<T, F, C>(
+    config: C,
+    developer_tip_ratio: Option<(Decimal, bool)>,
+    refund_policy: Option<RefundPolicy>,
+    testfn: T,
+) where
+    T: Fn(TestContext) -> F,
+    F: Future<Output = Result<()>>,
+    C: GetConfig,
+{
+    setup_test_funded(config, developer_tip_ratio, refund_policy, 10, testfn).await
 }
 
 async fn init_containers(cli: &Cli) -> (Monero, Containers<'_>) {


### PR DESCRIPTION
## Problem

Two swaps running at the same time can both select the same Monero output while building their lock transactions. wallet2 only marks an output spent after its lock transaction is relayed, and monero-sys has no reserve/freeze API, so the second lock becomes a permanent double-spend that monerod rejects, and that swap hangs until the cancel timelock (the recurring "xmr is refundable" reports).

A related case: when concurrent swaps together need more XMR than the maker holds, even a serialized second swap can be forced to reselect the first swap's freshly spent outputs, build a lock that double-spends, and then retry the rejected publish forever (the publish retry has no deadline), wedging until the cancel timelock.

## Fix

1. Serialize the construct-to-first-publish window with a process-wide async mutex, so at most one unpublished lock exists at a time. Overlapping swaps that are each fundable then pick different outputs and both succeed. A max-hold deadline releases the mutex if a swap wedges on a rejected publish, so one stuck swap cannot starve the others.
2. Under that guard, before constructing, check the wallet's unlocked balance against what the lock needs. If a concurrent swap already consumed the shared balance, fail with a permanent error that routes to an early Bitcoin refund (no Monero is locked, so this is safe) instead of building a doomed double-spend that wedges the swap.

## Testing

concurrent_bobs_before_xmr_lock_proof_sent and concurrent_bobs_after_xmr_lock_proof_sent (both swaps funded, both redeem), a new concurrent_bobs_insufficient_xmr (maker funded for only one of two concurrent swaps; the winner redeems, the loser refunds early rather than wedging), and happy_path all pass locally.

## Mainnet: two wedges followed end to end, two distinct failure signatures

Running this change on a live maker (deployed 2026-08-21), I followed two wedges to their endings. They split the problem cleanly:

**Swap `5eabdea8` (2026-08-26) — insufficient balance, missed by the pre-check.** Wallet held 13.156 XMR against a 13.963 XMR lock; the pre-check still **passed** (it never logged its refusal — a stale `unlocked_balance()` read), the publish was rejected with an empty-reason `TransactionRejected`, and the swap retried that same transaction until the cancel timelock, ~4.2h. The balance recovering mid-wedge (20.29 XMR unreserved for 33 minutes) changed nothing.

**Swap `0abd1dcd` (2026-08-27) — ample balance, unreachable by any balance check.** Wallet held 41.3 XMR unlocked against a 6.85 XMR lock; the pre-check was *right* to pass. But the constructed tx had selected outputs freshly spent by an earlier swap that wallet2 had not yet reflected, and monerod rejected that one fixed transaction **799 times over 3.9h** until the cancel timelock. Meanwhile the max-hold deadline released the mutex and sibling swap `4f885739` constructed with fresh outputs and completed end-to-end (locked, redeemed) **during the wedge** — the serialization half doing exactly its job. Neither wedge ever locked Monero; both takers were refunded on time.

What this pins down:

- The construct-time gate must operate on **outputs, not balance**: the daemon-side `is_key_image_spent` query, as the **primary** check. Happy to wire it in, and to extract the lock phase into a testable struct per the review comment.
- The two end-states want different exits. Insufficient funds routes to the early Bitcoin refund this PR adds. Sufficient-funds-but-stale-selection would have been **saved by rebuilding** the lock tx on rejection — the direction #1142 explores. The two are complementary, not competing.

## Relationship to #1142

#1142 explores rebuilding the lock transaction after a confirmed double-spend; the discussion there leaned toward aborting into a clean end state rather than rebuilding. This PR takes that route for the unfundable case — no Monero is ever locked, so there is nothing to rebuild. The `0abd1dcd` wedge above shows the other case is real too: with ample funds and a stale selection, a rebuild succeeds where any abort forfeits a fillable swap. Its `is_key_image_spent` signal slots directly into this PR's early-refund trigger either way.

## Related

- #120: managing Monero inputs across concurrent swaps.
- #138: earlier report of concurrent swaps colliding on the Monero lock.
- #1142: rebuild-on-confirmed-double-spend; complementary per the mainnet evidence above.
- monero-project/monero#2585: the wallet2 behaviour (no spent-state update before relay) behind the double-spend.

AI disclosure: I used Claude (Fable 5 and Opus 5) to help investigate and write this change. I understand the code, tested it, and am responsible for it.

## Update (rebase + review follow-up)

- Rebased on current master.
- Per review, the serialization now lives in `MoneroLockPhase` / `LockPhaseSession` (`swap/src/protocol/alice/lock_phase.rs`), a unit-tested struct — exclusivity, the max-hold deadline, the abandon → continue-unserialized → re-arm path, and permit release on drop are covered. `run_until` only reports whether its current state is inside the phase (`sync_to`) and reacts to `deadline()`.


## Independent field report (#1200)

An independent operator reproduced the residual case this PR explicitly flags. With #1193 applied on mainnet, two swaps constructed their lock tx ~3s apart and selected the same output: the first *published and released the mutex*, then the second *constructed while holding the mutex* but wallet2 had not yet reflected the first swap's spend, so it built a doomed lock that was rejected until the cancel timelock.

This independently confirms two things: (1) the mutex correctly serializes construct-through-first-publish (the second swap did wait its turn), and (2) the remaining window is wallet2's spent-output lag, not lock ordering — which is exactly the best-effort caveat noted above. The completion is #1142 (rebuild from fresh outputs on a confirmed double-spend) and/or a daemon `is_key_image_spent` check. **#1193 + #1142 is the recommended production pairing.**
