### PR TITLE
feat: add p2p.btc-xmr.com to the default rendezvous points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- GUI + CLI + ASB: Add `/dns4/p2p.btc-xmr.com/tcp/8890/p2p/12D3KooWBPe3sx6dDqE1RSzeBpH1ayghtBp4cgyymti5rPy79xWz` to the default list of rendezvous points
+
 - GUI: Support outbound connections to makers through libp2p circuit relays.
 
 ## [4.14.0] - 2026-08-22

--- a/src-gui/src/store/defaults.ts
+++ b/src-gui/src/store/defaults.ts
@@ -10,6 +10,7 @@ export const DEFAULT_RENDEZVOUS_POINTS = [
   "/dns4/discovery2.eigenwallet.org/tcp/443/wss/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE",
   "/onion3/av2jauifny7dgpvzhsnhra3cwivf6ofaefxvwhhuh5y7hsolabehhaad:8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE",
   "/dns4/p2p.myexchange.cash/tcp/443/wss/p2p/12D3KooWQQeUXdMkwJo8zESkKo7xek7NtVgqh1Q4RPnJCTmESX1Z",
+  "/dns4/p2p.btc-xmr.com/tcp/8890/p2p/12D3KooWBPe3sx6dDqE1RSzeBpH1ayghtBp4cgyymti5rPy79xWz",
 ];
 
 // Known broken rendezvous points to remove when applying defaults

--- a/swap-env/src/defaults.rs
+++ b/swap-env/src/defaults.rs
@@ -54,6 +54,7 @@ pub fn default_rendezvous_points() -> Vec<Multiaddr> {
         "/onion3/m6rboz5lv4wxldgybgox4pr4s6xci3h2exi5nogxaox762xji2gokuad:8891/p2p/12D3KooWGjcxdpsEWspGGwkQJ9BRJQjtBQFsLk36zJxrXSBPQWov".parse().unwrap(),
         "/dns4/discovery2.eigenwallet.org/tcp/443/wss/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE".parse().unwrap(),
         "/onion3/av2jauifny7dgpvzhsnhra3cwivf6ofaefxvwhhuh5y7hsolabehhaad:8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE".parse().unwrap(),
+        "/dns4/p2p.btc-xmr.com/tcp/8890/p2p/12D3KooWBPe3sx6dDqE1RSzeBpH1ayghtBp4cgyymti5rPy79xWz".parse().unwrap(),
     ]
 }
 


### PR DESCRIPTION
## What

Adds `/dns4/p2p.btc-xmr.com/tcp/8890/p2p/12D3KooWBPe3sx6dDqE1RSzeBpH1ayghtBp4cgyymti5rPy79xWz` to the default rendezvous points (Rust defaults + GUI defaults + changelog).

## Why

Peer discovery currently rests on very few working nodes: of the shipped defaults, `rendezvous.atomicworld.fun` is down, and `discovery2.eigenwallet.org` / `p2p.myexchange.cash` have been refusing registrations (`error=Unavailable`), which leaves `discovery.eigenwallet.org` and `dht.stealthswap.ninja` as the only reliable points. One more independent operator adds redundancy for both makers and takers.

## The node

- Runs on the same Hetzner infrastructure as the `maker-a.btc-xmr.com` ASB (mainnet maker, listed on the public registries), so it is maintained long-term with the same uptime incentive.
- Publicly reachable; already serving registrations (our own ASB registers on it hourly).
- Stable identity (persistent keypair).
